### PR TITLE
Fix sdkman_init_snippet should not evaluate $SDKMAN_DIR

### DIFF
--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -44,7 +44,7 @@ sdkman_platform=$(uname)
 sdkman_init_snippet=$( cat << EOF
 #THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!
 export SDKMAN_DIR="$SDKMAN_DIR"
-[[ -s "${SDKMAN_DIR}/bin/sdkman-init.sh" ]] && source "${SDKMAN_DIR}/bin/sdkman-init.sh"
+[[ -s "\${SDKMAN_DIR}/bin/sdkman-init.sh" ]] && source "\${SDKMAN_DIR}/bin/sdkman-init.sh"
 EOF
 )
 


### PR DESCRIPTION
When the snippet is written, SDKMAN_DIR var should not be interpreted as it is set just before, but written as is
